### PR TITLE
ADD: Using UserDefaults Data to cached data in neighborBook View

### DIFF
--- a/Views/NeighborGridView.swift
+++ b/Views/NeighborGridView.swift
@@ -84,6 +84,24 @@ class NeighborViewModel: ObservableObject {
                     
                     for book in books {
                         func getImage(bookuid : String) {
+                            if let imageData = UserDefaults.standard.data(forKey: bookuid) {
+                                let bookImage = Image(uiImage: UIImage(data: imageData)!)
+                                completionHandler(ViewModel(id: bookuid, useruid: book.get("userid") as! String ,
+                                                            name: book.get("username") as! String,
+                                                            email: book.get("useremail") as! String,
+                                                            bookname: book.get("bookname") as! String,
+                                                            author: book.get("author") as! String,
+                                                            title: book.get("title") as! String,
+                                                            content: book.get("content") as! String,
+                                                            created: (book.get("created") as! Timestamp).dateValue(),
+                                                            edited: (book.get("edited") as! Timestamp).dateValue(),
+                                                            price: book.get("price") as? Int,
+                                                            exchange: book.get("exchange") as! Bool,
+                                                            sell: book.get("sell") as! Bool,
+                                                            image: bookImage))
+                            } else {
+                            
+                            
                             Storage.storage().reference().child("images/books/\(bookuid)").getData(maxSize: 100 * 200 * 200) {
                                 (imageData, err) in
                                 if let _ = err as NSError? {
@@ -109,6 +127,7 @@ class NeighborViewModel: ObservableObject {
                                     if let imageData = imageData {
                                         bookImage = Image(uiImage: UIImage(data: imageData)!)
                                     }
+                                    UserDefaults.standard.set(imageData, forKey: bookuid)
                                     completionHandler(ViewModel(id: bookuid, useruid: book.get("userid") as! String ,
                                                                 name: book.get("username") as! String,
                                                                 email: book.get("useremail") as! String,
@@ -123,6 +142,7 @@ class NeighborViewModel: ObservableObject {
                                                                 sell: book.get("sell") as! Bool,
                                                                 image: bookImage))
                                 }
+                            }
                             }
                         }
                         getImage(bookuid: book.documentID)


### PR DESCRIPTION
스토리지 대역폭 사용량 최소화.

프로필 이미지와 다른 책 그리드뷰에 적용시켜봅시다.

나중에 책에서 이미지가 변경되는 기능이 생긴다면 수정 시간에 따라 새로 불러오는 기능 추가 필요.

#57 연관내용